### PR TITLE
Add stock models and migrations for stock tables

### DIFF
--- a/WebAPI.OpenFinance/Data/OpenFinanceContext.cs
+++ b/WebAPI.OpenFinance/Data/OpenFinanceContext.cs
@@ -20,5 +20,9 @@ namespace WebAPI.OpenFinance.Data
         public DbSet<CashModel> Cash { get; set; }
         public DbSet<CashInfoModel> CashInfo { get; set; }
 
+
+        //Stock tables
+        public DbSet<StockModel> Stock { get; set; }
+        public DbSet<StockInfoModel> StockInfo { get; set; }
     }
 }

--- a/WebAPI.OpenFinance/Migrations/20250129195931_AddingStocksModel.Designer.cs
+++ b/WebAPI.OpenFinance/Migrations/20250129195931_AddingStocksModel.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using WebAPI.OpenFinance.Data;
@@ -11,9 +12,11 @@ using WebAPI.OpenFinance.Data;
 namespace WebAPI.OpenFinance.Migrations
 {
     [DbContext(typeof(OpenFinanceContext))]
-    partial class OpenFinanceContextModelSnapshot : ModelSnapshot
+    [Migration("20250129195931_AddingStocksModel")]
+    partial class AddingStocksModel
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -243,11 +246,6 @@ namespace WebAPI.OpenFinance.Migrations
                         .IsRequired()
                         .HasColumnType("text")
                         .HasColumnName("stock_name");
-
-                    b.Property<string>("ticker")
-                        .IsRequired()
-                        .HasColumnType("text")
-                        .HasColumnName("ticker");
 
                     b.HasKey("stockId");
 

--- a/WebAPI.OpenFinance/Migrations/20250129195931_AddingStocksModel.cs
+++ b/WebAPI.OpenFinance/Migrations/20250129195931_AddingStocksModel.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace WebAPI.OpenFinance.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddingStocksModel : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "stock",
+                columns: table => new
+                {
+                    stock_id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    product_id = table.Column<int>(type: "integer", nullable: false),
+                    stock_name = table.Column<string>(type: "text", nullable: false),
+                    isin = table.Column<string>(type: "text", nullable: false),
+                    last_day_price = table.Column<decimal>(type: "numeric", nullable: false),
+                    currency = table.Column<string>(type: "text", nullable: false),
+                    exchange = table.Column<string>(type: "text", nullable: false),
+                    last_updated = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_stock", x => x.stock_id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "stock_info",
+                columns: table => new
+                {
+                    stock_info_id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    stock_id = table.Column<int>(type: "integer", nullable: false),
+                    connection_id = table.Column<int>(type: "integer", nullable: false),
+                    quantity = table.Column<int>(type: "integer", nullable: false),
+                    average_price = table.Column<decimal>(type: "numeric", nullable: false),
+                    last_updated = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_stock_info", x => x.stock_info_id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "stock");
+
+            migrationBuilder.DropTable(
+                name: "stock_info");
+        }
+    }
+}

--- a/WebAPI.OpenFinance/Migrations/20250129201003_AddingTicker.Designer.cs
+++ b/WebAPI.OpenFinance/Migrations/20250129201003_AddingTicker.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using WebAPI.OpenFinance.Data;
@@ -11,9 +12,11 @@ using WebAPI.OpenFinance.Data;
 namespace WebAPI.OpenFinance.Migrations
 {
     [DbContext(typeof(OpenFinanceContext))]
-    partial class OpenFinanceContextModelSnapshot : ModelSnapshot
+    [Migration("20250129201003_AddingTicker")]
+    partial class AddingTicker
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/WebAPI.OpenFinance/Migrations/20250129201003_AddingTicker.cs
+++ b/WebAPI.OpenFinance/Migrations/20250129201003_AddingTicker.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace WebAPI.OpenFinance.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddingTicker : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ticker",
+                table: "stock",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ticker",
+                table: "stock");
+        }
+    }
+}

--- a/WebAPI.OpenFinance/Models/StockInfoModel.cs
+++ b/WebAPI.OpenFinance/Models/StockInfoModel.cs
@@ -1,0 +1,39 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace WebAPI.OpenFinance.Models
+{
+    [Table("stock_info")]
+    public class StockInfoModel
+    {
+        /*
+         * table: stock_info
+         * stock_id (PK, int, not null)
+         * connection_id (FK, int, not null)
+         * quantity (int, not null)
+         * average_price (decimal(15,2), not null)
+         * last_updated (datetime, not null)
+         */
+
+        [Key]
+        [Column("stock_info_id")]
+        public int stockInfoId { get; init; }
+
+        [ForeignKey("stock")]
+        [Column("stock_id")]
+        public int stockId { get; set; }
+
+        [Column("connection_id")]
+        public int connectionId { get; set; }
+        
+        [Column("quantity")]
+        public int quantity { get; set; }
+
+        [Column("average_price")]
+        public decimal averagePrice { get; set; }
+
+        [Column("last_updated")]
+        public DateTime lastUpdated { get; set; }
+
+    }
+}

--- a/WebAPI.OpenFinance/Models/StockModel.cs
+++ b/WebAPI.OpenFinance/Models/StockModel.cs
@@ -1,0 +1,52 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace WebAPI.OpenFinance.Models
+{
+    [Table("stock")]
+    public class StockModel
+    {
+        /*
+         * Table: stock
+         * stock_id (PK, int, not null)
+         * product_id (FK, int, not null)
+         * stock_name (varchar(20), not null)
+         * ISIN (varchar(20), not null)
+         * last_day_price (decimal(10,2), not null)
+         * currency (varchar(10), not null)
+         * exchange (varchar(20), not null)
+         * last_updated (datetime, not null)
+         */
+
+        [Key]
+        [Column("stock_id")]
+        public int stockId { get; init; }
+
+        [ForeignKey("product_types")]
+        [Column("product_id")]
+        public int productId { get; set; }
+
+        [Column("ticker")]
+        public string ticker { get; set; }
+
+
+        [Column("stock_name")]
+        public string stockName { get; set; }
+
+        [Column("isin")]
+        public string ISIN { get; set; }
+
+        [Column("last_day_price")]
+        public decimal lastDayPrice { get; set; }
+
+        [Column("currency")]
+        public string currency { get; set; }
+    
+        [Column("exchange")]
+        public string exchange { get; set; }
+
+        [Column("last_updated")]
+        public DateTime lastUpdated { get; set; }
+
+    }
+}


### PR DESCRIPTION
Added DbSet<StockModel> and DbSet<StockInfoModel> to OpenFinanceContext. Updated OpenFinanceContextModelSnapshot for new entities. Created migration 20250129195931_AddingStocksModel for stock tables. Created migration 20250129201003_AddingTicker for ticker column. Added StockInfoModel class for stock_info table.
Added StockModel class for stock table.