### PR TITLE
Add foreign keys and indexes to OpenFinance models

### DIFF
--- a/WebAPI.OpenFinance/Migrations/20250204212040_UpdatingAllFKs.Designer.cs
+++ b/WebAPI.OpenFinance/Migrations/20250204212040_UpdatingAllFKs.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using WebAPI.OpenFinance.Data;
@@ -11,9 +12,11 @@ using WebAPI.OpenFinance.Data;
 namespace WebAPI.OpenFinance.Migrations
 {
     [DbContext(typeof(OpenFinanceContext))]
-    partial class OpenFinanceContextModelSnapshot : ModelSnapshot
+    [Migration("20250204212040_UpdatingAllFKs")]
+    partial class UpdatingAllFKs
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/WebAPI.OpenFinance/Migrations/20250204212040_UpdatingAllFKs.cs
+++ b/WebAPI.OpenFinance/Migrations/20250204212040_UpdatingAllFKs.cs
@@ -1,0 +1,183 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace WebAPI.OpenFinance.Migrations
+{
+    /// <inheritdoc />
+    public partial class UpdatingAllFKs : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "product_types",
+                table: "stock",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "product_types",
+                table: "cash",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_stock_info_connection_id",
+                table: "stock_info",
+                column: "connection_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_stock_info_stock_id",
+                table: "stock_info",
+                column: "stock_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_stock_product_types",
+                table: "stock",
+                column: "product_types");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_connections_bank_id",
+                table: "connections",
+                column: "bank_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_cash_info_cash_id",
+                table: "cash_info",
+                column: "cash_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_cash_info_connection_id",
+                table: "cash_info",
+                column: "connection_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_cash_product_types",
+                table: "cash",
+                column: "product_types");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_cash_product_types_product_types",
+                table: "cash",
+                column: "product_types",
+                principalTable: "product_types",
+                principalColumn: "product_id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_cash_info_cash_cash_id",
+                table: "cash_info",
+                column: "cash_id",
+                principalTable: "cash",
+                principalColumn: "cash_id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_cash_info_connections_connection_id",
+                table: "cash_info",
+                column: "connection_id",
+                principalTable: "connections",
+                principalColumn: "connection_id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_connections_banks_bank_id",
+                table: "connections",
+                column: "bank_id",
+                principalTable: "banks",
+                principalColumn: "bank_id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_stock_product_types_product_types",
+                table: "stock",
+                column: "product_types",
+                principalTable: "product_types",
+                principalColumn: "product_id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_stock_info_connections_connection_id",
+                table: "stock_info",
+                column: "connection_id",
+                principalTable: "connections",
+                principalColumn: "connection_id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_stock_info_stock_stock_id",
+                table: "stock_info",
+                column: "stock_id",
+                principalTable: "stock",
+                principalColumn: "stock_id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_cash_product_types_product_types",
+                table: "cash");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_cash_info_cash_cash_id",
+                table: "cash_info");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_cash_info_connections_connection_id",
+                table: "cash_info");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_connections_banks_bank_id",
+                table: "connections");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_stock_product_types_product_types",
+                table: "stock");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_stock_info_connections_connection_id",
+                table: "stock_info");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_stock_info_stock_stock_id",
+                table: "stock_info");
+
+            migrationBuilder.DropIndex(
+                name: "IX_stock_info_connection_id",
+                table: "stock_info");
+
+            migrationBuilder.DropIndex(
+                name: "IX_stock_info_stock_id",
+                table: "stock_info");
+
+            migrationBuilder.DropIndex(
+                name: "IX_stock_product_types",
+                table: "stock");
+
+            migrationBuilder.DropIndex(
+                name: "IX_connections_bank_id",
+                table: "connections");
+
+            migrationBuilder.DropIndex(
+                name: "IX_cash_info_cash_id",
+                table: "cash_info");
+
+            migrationBuilder.DropIndex(
+                name: "IX_cash_info_connection_id",
+                table: "cash_info");
+
+            migrationBuilder.DropIndex(
+                name: "IX_cash_product_types",
+                table: "cash");
+
+            migrationBuilder.DropColumn(
+                name: "product_types",
+                table: "stock");
+
+            migrationBuilder.DropColumn(
+                name: "product_types",
+                table: "cash");
+        }
+    }
+}

--- a/WebAPI.OpenFinance/Models/CashInfoModel.cs
+++ b/WebAPI.OpenFinance/Models/CashInfoModel.cs
@@ -19,13 +19,15 @@ namespace WebAPI.OpenFinance.Models
         [Column("cash_info_id")]
         public int cashInfoId { get; set; }
 
-        [ForeignKey("cash")]
         [Column("cash_id")]
         public int cashId { get; set; }
+        [ForeignKey("cashId")]
+        public CashModel Cash { get; set; }
 
-        [ForeignKey("connections")]
         [Column("connection_id")]
         public int connectionId { get; set; }
+        [ForeignKey("connectionId")]
+        public ConnectionsModel Connection { get; set; }
 
         [Column("amount")]
         public decimal amount { get; set; }

--- a/WebAPI.OpenFinance/Models/CashModel.cs
+++ b/WebAPI.OpenFinance/Models/CashModel.cs
@@ -16,9 +16,10 @@ namespace WebAPI.OpenFinance.Models
         [Column("cash_id")]
         public int cashId { get; set; }
         
-        [ForeignKey("product_types")]
         [Column("product_id")]
         public int productId { get; set; }
+        [ForeignKey("product_types")]
+        public ProductTypesModel Product { get; set; }
 
         [Required]
         [Column("cash_description")]

--- a/WebAPI.OpenFinance/Models/ConnectionsModel.cs
+++ b/WebAPI.OpenFinance/Models/ConnectionsModel.cs
@@ -23,9 +23,10 @@ namespace WebAPI.OpenFinance.Models
         [ForeignKey("clientID")]
         public ClientsModel Client { get; set; }
 
-        [ForeignKey("banks")]
         [Column("bank_id")]
         public int bankID { get; set; }
+        [ForeignKey("bankID")]
+        public BanksModel Bank { get; set; }
 
         [Required]
         [Column("account_number")]

--- a/WebAPI.OpenFinance/Models/StockInfoModel.cs
+++ b/WebAPI.OpenFinance/Models/StockInfoModel.cs
@@ -19,13 +19,16 @@ namespace WebAPI.OpenFinance.Models
         [Column("stock_info_id")]
         public int stockInfoId { get; init; }
 
-        [ForeignKey("stock")]
         [Column("stock_id")]
         public int stockId { get; set; }
+        [ForeignKey("stockId")]
+        public StockModel Stock { get; set; }
 
         [Column("connection_id")]
         public int connectionId { get; set; }
-        
+        [ForeignKey("connectionId")]
+        public ConnectionsModel Connection { get; set; }
+
         [Column("quantity")]
         public int quantity { get; set; }
 

--- a/WebAPI.OpenFinance/Models/StockModel.cs
+++ b/WebAPI.OpenFinance/Models/StockModel.cs
@@ -22,9 +22,10 @@ namespace WebAPI.OpenFinance.Models
         [Column("stock_id")]
         public int stockId { get; init; }
 
-        [ForeignKey("product_types")]
         [Column("product_id")]
         public int productId { get; set; }
+        [ForeignKey("product_types")]
+        public ProductTypesModel Product { get; set; }
 
         [Column("ticker")]
         public string ticker { get; set; }


### PR DESCRIPTION
Introduce new foreign key relationships and indexes to various models in the `WebAPI.OpenFinance` namespace. Updated `OpenFinanceContextModelSnapshot.cs` to include indexes for `cashId`, `connectionId`, `bankID`, `clientID`, and `stockId`. Added nullable `product_types` columns and indexes in `cash` and `stock` tables. Updated foreign key attributes and added navigation properties in `CashInfoModel`, `CashModel`, `ConnectionsModel`, `StockInfoModel`, and `StockModel`. Added migration `20250204212040_UpdatingAllFKs` to reflect these changes and enforce relationships between tables.