### PR TITLE
Add ClientCredentialModel and related database changes

### DIFF
--- a/WebAPI.OpenFinance/Data/OpenFinanceContext.cs
+++ b/WebAPI.OpenFinance/Data/OpenFinanceContext.cs
@@ -13,6 +13,7 @@ namespace WebAPI.OpenFinance.Data
         public DbSet<BanksModel> Banks { get; set; }
         public DbSet<ClientsModel> Clients { get; set; }
         public DbSet<ConnectionsModel> Connections { get; set; }
+        public DbSet<ClientCredentialModel> ClientCredentials { get; set; }
 
         public DbSet<ProductTypesModel> ProductsTypes { get; set; }
 
@@ -24,5 +25,15 @@ namespace WebAPI.OpenFinance.Data
         //Stock tables
         public DbSet<StockModel> Stock { get; set; }
         public DbSet<StockInfoModel> StockInfo { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            //Default value set to 3 for the remainingLoginAttempts
+            modelBuilder.Entity<ClientCredentialModel>(entity =>
+            {
+                entity.Property(e => e.remainingLoginAttempts)
+                      .HasDefaultValue(3);
+            });
+        }
     }
 }

--- a/WebAPI.OpenFinance/Migrations/20250204223330_AddingClientCredentialTable.Designer.cs
+++ b/WebAPI.OpenFinance/Migrations/20250204223330_AddingClientCredentialTable.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using WebAPI.OpenFinance.Data;
@@ -11,9 +12,11 @@ using WebAPI.OpenFinance.Data;
 namespace WebAPI.OpenFinance.Migrations
 {
     [DbContext(typeof(OpenFinanceContext))]
-    partial class OpenFinanceContextModelSnapshot : ModelSnapshot
+    [Migration("20250204223330_AddingClientCredentialTable")]
+    partial class AddingClientCredentialTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/WebAPI.OpenFinance/Migrations/20250204223330_AddingClientCredentialTable.cs
+++ b/WebAPI.OpenFinance/Migrations/20250204223330_AddingClientCredentialTable.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace WebAPI.OpenFinance.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddingClientCredentialTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "client_credential",
+                columns: table => new
+                {
+                    client_credential_id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    client_id = table.Column<int>(type: "integer", nullable: false),
+                    client_password = table.Column<string>(type: "text", nullable: false),
+                    last_login = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    remaining_login_attempts = table.Column<int>(type: "integer", nullable: false, defaultValue: 3)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_client_credential", x => x.client_credential_id);
+                    table.ForeignKey(
+                        name: "FK_client_credential_clients_client_id",
+                        column: x => x.client_id,
+                        principalTable: "clients",
+                        principalColumn: "client_id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_client_credential_client_id",
+                table: "client_credential",
+                column: "client_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "client_credential");
+        }
+    }
+}

--- a/WebAPI.OpenFinance/Models/ClientCredentialModel.cs
+++ b/WebAPI.OpenFinance/Models/ClientCredentialModel.cs
@@ -1,0 +1,41 @@
+﻿using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace WebAPI.OpenFinance.Models
+{
+    [Table("client_credential")]
+    public class ClientCredentialModel
+    {
+        /*
+         * Table: client_credential
+         * client_credential_id (PK, int, not null)
+         * client_id (FK (client table), int, not null)
+         * client_password (varchar(100), not null)
+         * last_login (datetime)
+         * remaining_login_attempts (int, DEFAULT 3)
+         */
+
+        [Key]
+        [Column("client_credential_id")]
+        public int clientCredentialId { get; init; }
+
+        [Column("client_id")]
+        public int clientId { get; set; }
+        [ForeignKey("clientId")]
+        public ClientsModel Client { get; set; }
+
+        [Required]
+        [Column("client_password")]
+        public string clientPassword { get; set; }
+
+        [Column("last_login")]
+        public DateTime? lastLogin { get; set; }
+
+        //Default value set at OnModelCreating
+        [Column("remaining_login_attempts")]
+        public int remainingLoginAttempts { get; set; }
+
+
+    }
+}


### PR DESCRIPTION
Introduce ClientCredentialModel to represent client credentials. Update OpenFinanceContext with DbSet and OnModelCreating method. Create migration for client_credential table and update model snapshot. Define ClientCredentialModel with properties and relationships.