### PR TITLE
Add mutual fund tables and foreign key relationships

### DIFF
--- a/WebAPI.OpenFinance/Data/OpenFinanceContext.cs
+++ b/WebAPI.OpenFinance/Data/OpenFinanceContext.cs
@@ -26,6 +26,10 @@ namespace WebAPI.OpenFinance.Data
         public DbSet<StockModel> Stock { get; set; }
         public DbSet<StockInfoModel> StockInfo { get; set; }
 
+        //Mutual Funds tables
+        public DbSet<MutualFundModel> MutualFund { get; set; }
+        public DbSet<MutualFundInfoModel> MutualFundInfo { get; set; }
+
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             //Default value set to 3 for the remainingLoginAttempts

--- a/WebAPI.OpenFinance/Migrations/20250213045343_AddMutualFundTables.Designer.cs
+++ b/WebAPI.OpenFinance/Migrations/20250213045343_AddMutualFundTables.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using WebAPI.OpenFinance.Data;
@@ -11,9 +12,11 @@ using WebAPI.OpenFinance.Data;
 namespace WebAPI.OpenFinance.Migrations
 {
     [DbContext(typeof(OpenFinanceContext))]
-    partial class OpenFinanceContextModelSnapshot : ModelSnapshot
+    [Migration("20250213045343_AddMutualFundTables")]
+    partial class AddMutualFundTables
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -293,12 +296,7 @@ namespace WebAPI.OpenFinance.Migrations
                         .HasColumnType("integer")
                         .HasColumnName("product_id");
 
-                    b.Property<int?>("product_types")
-                        .HasColumnType("integer");
-
                     b.HasKey("MFID");
-
-                    b.HasIndex("product_types");
 
                     b.ToTable("mutual_fund");
                 });
@@ -496,15 +494,6 @@ namespace WebAPI.OpenFinance.Migrations
                     b.Navigation("Connection");
 
                     b.Navigation("MutualFund");
-                });
-
-            modelBuilder.Entity("WebAPI.OpenFinance.Models.MutualFundModel", b =>
-                {
-                    b.HasOne("WebAPI.OpenFinance.Models.ProductTypesModel", "Product")
-                        .WithMany()
-                        .HasForeignKey("product_types");
-
-                    b.Navigation("Product");
                 });
 
             modelBuilder.Entity("WebAPI.OpenFinance.Models.StockInfoModel", b =>

--- a/WebAPI.OpenFinance/Migrations/20250213045343_AddMutualFundTables.cs
+++ b/WebAPI.OpenFinance/Migrations/20250213045343_AddMutualFundTables.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace WebAPI.OpenFinance.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMutualFundTables : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "mutual_fund",
+                columns: table => new
+                {
+                    mf_id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    product_id = table.Column<int>(type: "integer", nullable: false),
+                    mf_name = table.Column<string>(type: "text", nullable: false),
+                    mf_symbol = table.Column<string>(type: "text", nullable: false),
+                    mf_type = table.Column<string>(type: "text", nullable: false),
+                    mf_currency = table.Column<string>(type: "text", nullable: false),
+                    mf_last_nav = table.Column<decimal>(type: "numeric", nullable: false),
+                    mf_inception_date = table.Column<DateOnly>(type: "date", nullable: false),
+                    mf_management_fee = table.Column<decimal>(type: "numeric", nullable: false),
+                    last_updated = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_mutual_fund", x => x.mf_id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "mutual_fund_info",
+                columns: table => new
+                {
+                    mfi_id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    mf_id = table.Column<int>(type: "integer", nullable: false),
+                    connection_id = table.Column<int>(type: "integer", nullable: false),
+                    connectionID = table.Column<int>(type: "integer", nullable: false),
+                    quantity_shares = table.Column<int>(type: "integer", nullable: false),
+                    average_nav = table.Column<decimal>(type: "numeric", nullable: false),
+                    last_updated = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_mutual_fund_info", x => x.mfi_id);
+                    table.ForeignKey(
+                        name: "FK_mutual_fund_info_connections_connectionID",
+                        column: x => x.connectionID,
+                        principalTable: "connections",
+                        principalColumn: "connection_id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_mutual_fund_info_mutual_fund_mf_id",
+                        column: x => x.mf_id,
+                        principalTable: "mutual_fund",
+                        principalColumn: "mf_id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_mutual_fund_info_connectionID",
+                table: "mutual_fund_info",
+                column: "connectionID");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_mutual_fund_info_mf_id",
+                table: "mutual_fund_info",
+                column: "mf_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "mutual_fund_info");
+
+            migrationBuilder.DropTable(
+                name: "mutual_fund");
+        }
+    }
+}

--- a/WebAPI.OpenFinance/Migrations/20250213045651_AddMutualFundProdFK.Designer.cs
+++ b/WebAPI.OpenFinance/Migrations/20250213045651_AddMutualFundProdFK.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using WebAPI.OpenFinance.Data;
@@ -11,9 +12,11 @@ using WebAPI.OpenFinance.Data;
 namespace WebAPI.OpenFinance.Migrations
 {
     [DbContext(typeof(OpenFinanceContext))]
-    partial class OpenFinanceContextModelSnapshot : ModelSnapshot
+    [Migration("20250213045651_AddMutualFundProdFK")]
+    partial class AddMutualFundProdFK
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/WebAPI.OpenFinance/Migrations/20250213045651_AddMutualFundProdFK.cs
+++ b/WebAPI.OpenFinance/Migrations/20250213045651_AddMutualFundProdFK.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace WebAPI.OpenFinance.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMutualFundProdFK : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "product_types",
+                table: "mutual_fund",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_mutual_fund_product_types",
+                table: "mutual_fund",
+                column: "product_types");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_mutual_fund_product_types_product_types",
+                table: "mutual_fund",
+                column: "product_types",
+                principalTable: "product_types",
+                principalColumn: "product_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_mutual_fund_product_types_product_types",
+                table: "mutual_fund");
+
+            migrationBuilder.DropIndex(
+                name: "IX_mutual_fund_product_types",
+                table: "mutual_fund");
+
+            migrationBuilder.DropColumn(
+                name: "product_types",
+                table: "mutual_fund");
+        }
+    }
+}

--- a/WebAPI.OpenFinance/Models/MutualFundInfoModel.cs
+++ b/WebAPI.OpenFinance/Models/MutualFundInfoModel.cs
@@ -1,0 +1,43 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace WebAPI.OpenFinance.Models
+{
+    [Table("mutual_fund_info")]
+    public class MutualFundInfoModel
+    {
+        /*
+         * Table: mutual_fund_info
+         * mfi_id (PK, int, not null)
+         * mf_id (FK, int, not null)
+         * connetion_id (FK, int, not null)
+         * qty_shares (int, not null)
+         * average_nav (decimal(15, 2), not null)
+         * last_updated (datetime, not null)
+         */
+
+        [Key]
+        [Column("mfi_id")]
+        public int MFIID { get; init; }
+
+        [Column("mf_id")]
+        public int MFID { get; set; }
+        [ForeignKey("MFID")]
+        public MutualFundModel MutualFund { get; set; }
+
+        [Column("connection_id")]
+        public int ConnectionID { get; set; }
+        [ForeignKey("connectionID")]
+        public ConnectionsModel Connection { get; set; }
+
+        [Column("quantity_shares")]
+        public int QuantityShares { get; set; }
+
+        [Column("average_nav")]
+        public decimal AverageNAV { get; set; }
+
+        [Column("last_updated")]
+        public DateTime LastUpdated { get; set; }
+
+    }
+}

--- a/WebAPI.OpenFinance/Models/MutualFundModel.cs
+++ b/WebAPI.OpenFinance/Models/MutualFundModel.cs
@@ -1,0 +1,60 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace WebAPI.OpenFinance.Models
+{
+    [Table("mutual_fund")]
+    public class MutualFundModel
+    {
+        /*
+         * Table: Fund
+         * mf_id (PK, int, not null)
+         * product_id (FK, int, not null)
+         * mf_name (varchar(100), not null)
+         * mf_symbol (varchar(100), not null)
+         * mf_type (varchar(100), not null)
+         * mf_currency (varchar(100), not null)
+         * mf_price (decimal(10,2), not null)
+         * mf_nav (decimal(5,5))
+         * mf_quantity (int, not null)
+         * mf_inception_date (datetime, not null)
+         * mf_management_fee (decimal(5,5), not null)
+         * last_updated (datetime, not null)
+         */
+
+        [Key]
+        [Column("mf_id")]
+        public int MFID { get; set; }
+
+        [Column("product_id")]
+        public int productId { get; set; }
+        [ForeignKey("product_types")]
+        public ProductTypesModel Product { get; set; }
+
+        [Column("mf_name")]
+        public string MFName { get; set; }
+
+        [Column("mf_symbol")]
+        public string MFSymbol { get; set; }
+
+        [Column("mf_type")]
+        public string MFType { get; set; }
+
+        [Column("mf_currency")]
+        public string MFCurrency { get; set; }
+
+        [Column("mf_last_nav")]
+        public decimal MFNAV { get; set; }
+
+        [Column("mf_inception_date")]
+        public DateOnly MFInceptionDate { get; set; }
+
+        [Column("mf_management_fee")]
+        public decimal MFManagementFee { get; set; }
+
+        [Column("last_updated")]
+        public DateTime lastUpdated { get; init; }
+
+
+    }
+}

--- a/WebAPI.OpenFinance/Models/StockInfoModel.cs
+++ b/WebAPI.OpenFinance/Models/StockInfoModel.cs
@@ -9,7 +9,7 @@ namespace WebAPI.OpenFinance.Models
         /*
          * table: stock_info
          * stock_id (PK, int, not null)
-         * connection_id (FK, int, not null)
+         * connection_id (FK, int, not null)    
          * quantity (int, not null)
          * average_price (decimal(15,2), not null)
          * last_updated (datetime, not null)


### PR DESCRIPTION
Introduce new mutual fund tables in OpenFinanceContext with DbSet properties for MutualFund and MutualFundInfo. Create migration 20250213045343_AddMutualFundTables to handle schema changes, including mutual_fund and mutual_fund_info tables. Add foreign key constraints and indexes for optimization.

Add migration 20250213045651_AddMutualFundProdFK to establish foreign key relationship between mutual_fund and product_types tables. Update OpenFinanceContextModelSnapshot, add MutualFundInfoModel and MutualFundModel classes, and make minor formatting changes in StockInfoModel.